### PR TITLE
Add GitHub provider owner

### DIFF
--- a/module/provider.tf
+++ b/module/provider.tf
@@ -1,10 +1,14 @@
 terraform {
   required_providers {
-		aws = {
-			source = "hashicorp/aws"
-		}
-		github = {
-			source = "integrations/github"
-		}
-	}
+    aws = {
+      source = "hashicorp/aws"
+    }
+    github = {
+      source = "integrations/github"
+    }
+  }
+}
+
+provider "github" {
+  owner = "tetsuya28"
 }


### PR DESCRIPTION
Fix
```
│ Error: GET https://api.github.com/user: 401 Requires authentication []
│ 
│   with provider["registry.terraform.io/integrations/github"],
│   on providers.tf line 12, in provider "github":
│   12: provider "github" {}
│ 
```