### PR TITLE
Fix Lambda policy

### DIFF
--- a/module/main.tf
+++ b/module/main.tf
@@ -86,7 +86,7 @@ EOF
 resource "aws_iam_policy" "this" {
   name        = var.name
   path        = "/"
-  description = "IAM policy for logging from a lambda"
+  description = "IAM policy for lambda"
   policy      = <<EOF
 {
   "Version": "2012-10-17",
@@ -96,7 +96,8 @@ resource "aws_iam_policy" "this" {
         "logs:CreateLogGroup",
         "logs:CreateLogStream",
         "logs:PutLogEvents",
-        "ce:*"
+        "ce:*",
+				"account:GetContactInformation"
       ],
       "Resource": "*",
       "Effect": "Allow"

--- a/module/main.tf
+++ b/module/main.tf
@@ -97,7 +97,7 @@ resource "aws_iam_policy" "this" {
         "logs:CreateLogStream",
         "logs:PutLogEvents",
         "ce:*",
-				"account:GetContactInformation"
+        "account:GetContactInformation"
       ],
       "Resource": "*",
       "Effect": "Allow"


### PR DESCRIPTION
Fix Lambda policy

```
{
  "errorMessage": "operation error Account: GetContactInformation, https response error StatusCode: 403, RequestID: 17b2e0a5-f98a-4599-a20b-8b9d02ffc9b4, AccessDeniedException: User: arn:aws:sts::XXX:assumed-role/aws-cost-report/aws-cost-report is not authorized to perform: account:GetContactInformation on resource: arn:aws:account::XXX:account",
  "errorType": "OperationError"
}
```
